### PR TITLE
Avoid property renaming on message event data

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,5 +1,3 @@
-/* eslint-disable dot-notation */
-
 /**
  * Create a function for running operations.
  * @param {function(Array, Object):*} operation The operation.

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -89,7 +89,7 @@ function createFauxWorker(config, onMessage) {
   return {
     postMessage: function(data) {
       setTimeout(function() {
-        onMessage({data: {buffer: minion(data), meta: data.meta}});
+        onMessage({'data': {'buffer': minion(data), 'meta': data['meta']}});
       }, 0);
     }
   };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -55,7 +55,7 @@ function createMinion(operation) {
 /**
  * Create a worker for running operations.
  * @param {Object} config Configuration.
- * @param {function(Object)} onMessage Called with a message event.
+ * @param {function(MessageEvent)} onMessage Called with a message event.
  * @return {Worker} The worker.
  */
 function createWorker(config, onMessage) {
@@ -65,9 +65,9 @@ function createWorker(config, onMessage) {
 
   var lines = lib.concat([
     'var __minion__ = (' + createMinion.toString() + ')(', config.operation.toString(), ');',
-    'self.addEventListener("message", function(__event__) {',
-    '  var buffer = __minion__(__event__.data);',
-    '  self.postMessage({buffer: buffer, meta: __event__.data.meta}, [buffer]);',
+    'self.addEventListener("message", function(event) {',
+    '  var buffer = __minion__(event.data);',
+    '  self.postMessage({buffer: buffer, meta: event.data.meta}, [buffer]);',
     '});'
   ]);
 
@@ -81,7 +81,7 @@ function createWorker(config, onMessage) {
 /**
  * Create a faux worker for running operations.
  * @param {Object} config Configuration.
- * @param {function(Object)} onMessage Called with a message event.
+ * @param {function(MessageEvent)} onMessage Called with a message event.
  * @return {Object} The faux worker.
  */
 function createFauxWorker(config, onMessage) {
@@ -210,7 +210,7 @@ Processor.prototype._dispatch = function() {
 /**
  * Handle messages from the worker.
  * @param {number} index The worker index.
- * @param {Object} event The message event.
+ * @param {MessageEvent} event The message event.
  */
 Processor.prototype._onWorkerMessage = function(index, event) {
   if (this._destroyed) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "extends": "tschaub",
     "globals": {
       "ImageData": false
+    },
+    "rules": {
+      "dot-notation": 0
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# **⚙ pixelworks**
+# **pixelworks**
 
 Utilities for working with [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) in [`Workers`](https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker).
 


### PR DESCRIPTION
This prevents property renaming on event message data when the library is minified.  Because worker code is created with strings, worker code accesses message event data with property names that are not changed during minification.  The faux-worker needs to behave the same way - accessing the same property names regardless of minification.