### PR TITLE
Workaround for lack of ImageData constructor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - 0.12
+cache:
+  directories:
+    - node_modules
 env:
   global:
     - secure: ZRuykw2aNwaDzhtwoks7K7BEG+dphpGWdqsnTfl2BjbjMhO6uAiVGeqbbaXeuJzV2kue4N5BiodQ/d0NQoaLVIzdt2Te+Ht1QlSauCeM5f7X4NeJU+LItS8mwdJz7FRsFrg6OknYYxCvYmKGs20QeMsqDB5S4D6Qx7LqUpWnzECXrHaTCel16xoHO6QK2/LPAh8BrD0u+tdI4GR8LME1/YaNHwHDphGyQJDl5gWlcUMrwO/OFU2q0/M5KRJ0vhQ4ewtezYTkDl4L7YyCPAc4WskyMe/kqZJUUSfnJguKguPePRxBUJ+QD+VmDEAr6hMXUlM4GrLaMjfugZtokJxGEVwO3+EXrkXXQkOpDLsAo6WSqxO9h/05Xc6xXC1jx+oysiI2MTaZF3rJecGhfTKfiMTKOpWrDsZTQ7vCyXWv3AWHllK+DQZelV51V/q2EoE1w5YyM8ZSDRWmO56W6u9MRpMD/mV2G+T9ANftuVLGdzk3Xk8PC2/KPzX1M+3LfjFL4z7SIOen65TrTZ3SwgsgZJMyp2IcNLNnyFKYGNhg/7DzUO//7Cg+HIIgUzIaSo7URjgg3R+YcjUz0m3mHLtGdEGeuxE+VGnixkeGxrnQ5eVO7cEyZyMskVA7i3mYwwS4adXHTUpQ4FJ/W50UflK8egbJBZJ16jkI+H4yq1L13Qs=

--- a/examples/operations.js
+++ b/examples/operations.js
@@ -1,6 +1,6 @@
 /* global pixelworks */
 
-var luminance = function(pixels, data) {
+var luminance = function(pixels) {
   var pixel = pixels[0];
   var l = 0.2126 * pixel[0] + 0.7152 * pixel[1] + 0.0722 * pixel[2];
   pixel[0] = l;
@@ -20,7 +20,7 @@ var color = function(pixels, data) {
   } else {
     pixel[3] = 0;
   }
-  return pixels;
+  return pixel;
 };
 
 var inputContext = document.getElementById('input').getContext('2d');
@@ -28,7 +28,13 @@ var outputContext = document.getElementById('output').getContext('2d');
 var image = new Image();
 
 var worker = new pixelworks.Processor({
-  operations: [luminance, color]
+  operation: function(pixels, data) {
+    return color(luminance(pixels), data);
+  },
+  lib: {
+    luminance: luminance,
+    color: color
+  }
 });
 
 var threshold = document.getElementById('threshold');

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,21 +1,4 @@
-var hasImageData = true;
-try {
-  new ImageData(10, 10);
-} catch (_) {
-  hasImageData = false;
-}
-
-var context = document.createElement('canvas').getContext('2d');
-
-function newImageData(data, width, height) {
-  if (hasImageData) {
-    return new ImageData(data, width, height);
-  } else {
-    var imageData = context.createImageData(width, height);
-    imageData.data.set(data);
-    return imageData;
-  }
-}
+var newImageData = require('./util').newImageData;
 
 /**
  * Create a function for running operations.  This function is serialized for

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,11 +1,46 @@
+var hasImageData = true;
+try {
+  new ImageData(10, 10);
+} catch (_) {
+  hasImageData = false;
+}
+
+var context = document.createElement('canvas').getContext('2d');
+
+function newImageData(data, width, height) {
+  if (hasImageData) {
+    return new ImageData(data, width, height);
+  } else {
+    var imageData = context.createImageData(width, height);
+    imageData.data.set(data);
+    return imageData;
+  }
+}
+
 /**
- * Create a function for running operations.
+ * Create a function for running operations.  This function is serialized for
+ * use in a worker.
  * @param {function(Array, Object):*} operation The operation.
  * @return {function(Object):ArrayBuffer} A function that takes an object with
  * buffers, meta, imageOps, width, and height properties and returns an array
  * buffer.
  */
 function createMinion(operation) {
+  var workerHasImageData = true;
+  try {
+    new ImageData(10, 10);
+  } catch (_) {
+    workerHasImageData = false;
+  }
+
+  function newWorkerImageData(data, width, height) {
+    if (workerHasImageData) {
+      return new ImageData(data, width, height);
+    } else {
+      return {data: data, width: width, height: height};
+    }
+  }
+
   return function(data) {
     // bracket notation for minification support
     var buffers = data['buffers'];
@@ -21,7 +56,7 @@ function createMinion(operation) {
     if (imageOps) {
       var images = new Array(numBuffers);
       for (b = 0; b < numBuffers; ++b) {
-        images[b] = new ImageData(
+        images[b] = newWorkerImageData(
             new Uint8ClampedArray(buffers[b]), width, height);
       }
       output = operation(images, meta).data;
@@ -249,7 +284,7 @@ Processor.prototype._resolveJob = function() {
   this._job = null;
   this._dataLookup = {};
   job.callback(null,
-      new ImageData(data, job.inputs[0].width, job.inputs[0].height), meta);
+      newImageData(data, job.inputs[0].width, job.inputs[0].height), meta);
   this._dispatch();
 };
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,20 @@
+var hasImageData = true;
+try {
+  new ImageData(10, 10);
+} catch (_) {
+  hasImageData = false;
+}
+
+var context = document.createElement('canvas').getContext('2d');
+
+function newImageData(data, width, height) {
+  if (hasImageData) {
+    return new ImageData(data, width, height);
+  } else {
+    var imageData = context.createImageData(width, height);
+    imageData.data.set(data);
+    return imageData;
+  }
+}
+
+exports.newImageData = newImageData;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "karma-browserify": "^5.0.2",
     "karma-chrome-launcher": "^0.2.2",
     "karma-mocha": "^0.2.2",
-    "karma-sauce-launcher": "^0.3.0",
+    "karma-sauce-launcher": "^0.3.1",
     "mocha": "^2.4.5",
     "sinon": "^1.17.3",
     "watchify": "^3.7.0"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "pretest": "eslint lib test examples",
-    "test": "karma start --single-run",
-    "start": "karma start",
+    "test": "karma start test/karma.conf.js --single-run",
+    "start": "karma start test/karma.conf.js",
     "bundle": "mkdir -p dist && browserify lib/index.js --standalone pixelworks > dist/pixelworks.js",
     "prepublish": "npm run bundle"
   },

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -2,9 +2,9 @@ module.exports = function(karma) {
 
   karma.set({
     frameworks: ['browserify', 'mocha'],
-    files: ['test/**/*.js'],
+    files: ['**/*.test.js'],
     preprocessors: {
-      'test/**/*.js': ['browserify']
+      '**/*.test.js': ['browserify']
     },
     browserify: {
       debug: true
@@ -26,6 +26,12 @@ module.exports = function(karma) {
       'SL_Firefox': {
         base: 'SauceLabs',
         browserName: 'firefox'
+      },
+      'SL_IE_11': {
+        base: 'SauceLabs',
+        browserName: 'internet explorer',
+        platform: 'Windows 8.1',
+        version: '11'
       }
     };
     karma.set({
@@ -37,8 +43,8 @@ module.exports = function(karma) {
         }
       },
       reporters: ['dots', 'saucelabs'],
-      captureTimeout: 120000,
-      browserNoActivityTimeout: 50000,
+      captureTimeout: 240000,
+      browserNoActivityTimeout: 240000,
       customLaunchers: customLaunchers,
       browsers: Object.keys(customLaunchers)
     });

--- a/test/lib/processor.test.js
+++ b/test/lib/processor.test.js
@@ -1,8 +1,9 @@
 /* eslint-env mocha */
-var assert = require('chai').assert;
-var sinon = require('sinon');
 
 var Processor = require('../../lib/processor');
+var assert = require('chai').assert;
+var newImageData = require('../../lib/util').newImageData;
+var sinon = require('sinon');
 
 describe('Processor', function() {
 
@@ -36,7 +37,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {count: 0, sum: 0}, function(err, output, m) {
         if (err) {
@@ -64,7 +65,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {}, function(err, output, m) {
         if (err) {
@@ -106,7 +107,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([10, 2, 0, 0, 5, 8, 0, 1]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {}, function(err, output, m) {
         if (err) {
@@ -145,7 +146,7 @@ describe('Processor', function() {
       }
 
       for (var i = 0; i < 5; ++i) {
-        var input = new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1);
+        var input = newImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1);
         processor.process([input], {}, createCallback(i));
       }
 
@@ -174,7 +175,7 @@ describe('Processor', function() {
       }
 
       for (var i = 0; i < 5; ++i) {
-        var input = new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1);
+        var input = newImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1);
         processor.process([input], {}, createCallback(i));
       }
 
@@ -205,7 +206,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {}, function(err, output, m) {
         if (err) {
@@ -227,7 +228,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4]);
-      var input = new ImageData(array, 1, 1);
+      var input = newImageData(array, 1, 1);
       var meta = {foo: 'bar'};
 
       processor.process([input], meta, function(err, output, m) {
@@ -253,7 +254,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {}, function() {
         done(new Error('Expected abort to stop callback from being called'));
@@ -276,7 +277,7 @@ describe('Processor', function() {
       });
 
       var array = new Uint8ClampedArray([1, 2, 3, 4, 5, 6, 7, 8]);
-      var input = new ImageData(array, 1, 2);
+      var input = newImageData(array, 1, 2);
 
       processor.process([input], {}, function() {
         done(new Error('Expected abort to stop callback from being called'));


### PR DESCRIPTION
Internet Explorer lacks the `ImageData` constructor (vote here to support its addition: https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/8804656-support-for-the-imagedata-constructor).

This branch makes it so within a worker, if the `ImageData` constructor is not available, an `ImageData`-like object is used (with `data`, `width`, and `height` properties).  Outside of the worker, a Canvas 2d context is created and `ImageData` is created with `context.createImageData()`.
