### PR TITLE
Terminate workers on destroy

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -109,11 +109,18 @@ function createWorker(config, onMessage) {
  */
 function createFauxWorker(config, onMessage) {
   const minion = createMinion(config.operation);
+  let terminated = false;
   return {
     postMessage: function(data) {
       setTimeout(function() {
+        if (terminated) {
+          return;
+        }
         onMessage({data: {buffer: minion(data), meta: data['meta']}});
       }, 0);
+    },
+    terminate: function() {
+      terminated = true;
     }
   };
 }
@@ -171,6 +178,9 @@ Processor.prototype.process = function(inputs, meta, callback) {
  * Stop responding to any completed work and destroy the processor.
  */
 Processor.prototype.destroy = function() {
+  for (let i = 0; i < this._workers.length; ++i) {
+    this._workers[i].terminate();
+  }
   for (const key in this) {
     this[key] = null;
   }


### PR DESCRIPTION
This makes it so workers are terminated when calling `processor.destroy()`.

Fixes #74.